### PR TITLE
feat(react): use renamed package with appropriate version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebral-module-recorder",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A state recorder for Cerebral",
   "main": "index.js",
   "scripts": {
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/cerebral/cerebral-module-recorder#readme",
   "devDependencies": {
-    "babel-loader": "^5.3.2",
-    "webpack": "^1.5.3",
-    "react": "^0.14.0",
-    "cerebral-react": "^0.9.0"
+    "babel-loader": "^5.4.0",
+    "webpack": "^1.12.10",
+    "react": "^0.14.6",
+    "cerebral-view-react": "^0.10.1"
   }
 }

--- a/react/SimpleRecorder/index.js
+++ b/react/SimpleRecorder/index.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var Cerebral = require('cerebral-react').Mixin;
+var Cerebral = require('cerebral-view-react').Mixin;
 
 module.exports = React.createClass({
   mixins: [Cerebral],


### PR DESCRIPTION
BREAKING CHANGE:
Please check that you replaced `cerbral-react` with latest `cerebral-view-react` anywhere in your components